### PR TITLE
#181 Bindings for CloseableHttpClient moved to AemCommonModule

### DIFF
--- a/bb-aem-classic/src/main/java/com/cognifide/qa/bb/AemClassicModule.java
+++ b/bb-aem-classic/src/main/java/com/cognifide/qa/bb/AemClassicModule.java
@@ -19,18 +19,12 @@
  */
 package com.cognifide.qa.bb;
 
-import org.apache.http.impl.client.CloseableHttpClient;
-
 import com.cognifide.qa.bb.aem.dialog.configurer.ComponentConfigurerFactory;
 import com.cognifide.qa.bb.aem.ui.DialogFieldProvider;
-import com.cognifide.qa.bb.constants.AemConfigKeys;
 import com.cognifide.qa.bb.mapper.field.FieldProvider;
-import com.cognifide.qa.bb.provider.http.HttpClientProvider;
 import com.google.inject.AbstractModule;
-import com.google.inject.Provides;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.multibindings.Multibinder;
-import com.google.inject.name.Named;
 
 /**
  * This module contains:
@@ -40,22 +34,6 @@ import com.google.inject.name.Named;
  * </ul>
  */
 public class AemClassicModule extends AbstractModule {
-
-  /**
-   * Provider method that produces a CloseableHttpClient instances configured with URL, login and password
-   * taken from property files.
-   *
-   * @param url      IP address of Author instance, automatically set to author.ip property.
-   * @param login    Author login, automatically set to author.login property.
-   * @param password Author password, automatically set to author.password property.
-   * @return New instance of CloseableHttpClient.
-   */
-  @Provides
-  public CloseableHttpClient getAuthorHttpClient(@Named(AemConfigKeys.AUTHOR_IP) String url,
-      @Named(AemConfigKeys.AUTHOR_LOGIN) String login,
-      @Named(AemConfigKeys.AUTHOR_PASSWORD) String password) {
-    return new HttpClientProvider(login, password, url).get();
-  }
 
   @Override
   protected void configure() {

--- a/bb-aem-common/src/main/java/com/cognifide/qa/bb/aem/AemCommonModule.java
+++ b/bb-aem-common/src/main/java/com/cognifide/qa/bb/aem/AemCommonModule.java
@@ -21,14 +21,19 @@ package com.cognifide.qa.bb.aem;
 
 import java.util.Properties;
 
-import com.cognifide.qa.bb.constants.ConfigKeys;
+import org.apache.http.impl.client.CloseableHttpClient;
+
 import com.cognifide.qa.bb.constants.AemConfigFilenames;
 import com.cognifide.qa.bb.constants.AemConfigKeys;
+import com.cognifide.qa.bb.constants.ConfigKeys;
+import com.cognifide.qa.bb.provider.http.HttpClientProvider;
 import com.cognifide.qa.bb.provider.jcr.properties.AuthorProperties;
 import com.cognifide.qa.bb.provider.jcr.properties.InstanceProperties;
 import com.cognifide.qa.bb.provider.jcr.properties.PublishProperties;
 import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
+import com.google.inject.Provides;
+import com.google.inject.name.Named;
 import com.google.inject.name.Names;
 
 /**
@@ -51,6 +56,22 @@ public class AemCommonModule extends AbstractModule {
         properties.put(ConfigKeys.BASE_URL, publishUrl);
       }
     });
+  }
+
+  /**
+   * Provider method that produces a CloseableHttpClient instances configured with URL, login and password
+   * taken from property files.
+   *
+   * @param url      IP address of Author instance, automatically set to author.ip property.
+   * @param login    Author login, automatically set to author.login property.
+   * @param password Author password, automatically set to author.password property.
+   * @return New instance of CloseableHttpClient.
+   */
+  @Provides
+  public CloseableHttpClient getAuthorHttpClient(@Named(AemConfigKeys.AUTHOR_IP) String url,
+      @Named(AemConfigKeys.AUTHOR_LOGIN) String login,
+      @Named(AemConfigKeys.AUTHOR_PASSWORD) String password) {
+    return new HttpClientProvider(login, password, url).get();
   }
 
 }


### PR DESCRIPTION
From now on, using CloseableHttpClient will require installing `AemCommonModule`