### PR TITLE
#227 Additonal contexts can now be loaded from separate files

### DIFF
--- a/bb-core-tests/src/test/java/com/cognifide/qa/bb/config/YamlConfigTest.java
+++ b/bb-core-tests/src/test/java/com/cognifide/qa/bb/config/YamlConfigTest.java
@@ -1,0 +1,76 @@
+/*-
+ * #%L
+ * Bobcat
+ * %%
+ * Copyright (C) 2016 Cognifide Ltd.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.cognifide.qa.bb.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.MapEntry.entry;
+
+import java.util.Properties;
+
+import org.junit.Test;
+
+import com.cognifide.qa.bb.modules.CoreModule;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+public class YamlConfigTest {
+
+  @Test
+  public void additionalContextsShouldBeLoadedWhenSelectedInConfig() {
+    Properties properties = getInjector().getInstance(Properties.class);
+
+    assertThat(properties)
+        .contains(
+            entry("property1", "value1"),
+            entry("property2", "value2"),
+            entry("prop3", "val3"),
+            entry("prop4", "val4"))
+        .doesNotContain(
+            entry("prop1", "val1"),
+            entry("prop2", "val2"),
+            entry("property3", "value3"),
+            entry("property4", "value4")
+        );
+  }
+
+  @Test
+  public void additionalNestedContextsShouldBeLoadedWhenSelectedInConfig() {
+    System.setProperty("bobcat.config.contexts", "additional-context2,nested-context");
+    Properties properties = getInjector().getInstance(Properties.class);
+
+    assertThat(properties)
+        .contains(
+            entry("property1", "value1"),
+            entry("property2", "value2"),
+            entry("property3", "value3"),
+            entry("property4", "value4"));
+  }
+
+  private Injector getInjector() {
+    System.setProperty("bobcat.config", "yaml");
+    return Guice.createInjector(new AbstractModule() {
+      @Override
+      protected void configure() {
+        install(new CoreModule());
+      }
+    });
+  }
+}

--- a/bb-core-tests/src/test/resources/config.yaml
+++ b/bb-core-tests/src/test/resources/config.yaml
@@ -1,5 +1,5 @@
 default:
-  contexts: [firefox]
+  contexts: [firefox, additional-context1, additional-context4]
 
 contexts:
     firefox:

--- a/bb-core-tests/src/test/resources/contexts/another-test-context.yaml
+++ b/bb-core-tests/src/test/resources/contexts/another-test-context.yaml
@@ -1,0 +1,6 @@
+additional-context3:
+  prop1: val1
+  prop2: val2
+additional-context4:
+  prop3: val3
+  prop4: val4

--- a/bb-core-tests/src/test/resources/contexts/nested/nested-test-context.yaml
+++ b/bb-core-tests/src/test/resources/contexts/nested/nested-test-context.yaml
@@ -1,0 +1,3 @@
+nested-context:
+  property1: value1
+  property2: value2

--- a/bb-core-tests/src/test/resources/contexts/test-context.yaml
+++ b/bb-core-tests/src/test/resources/contexts/test-context.yaml
@@ -1,0 +1,6 @@
+additional-context1:
+  property1: value1
+  property2: value2
+additional-context2:
+  property3: value3
+  property4: value4

--- a/bb-core/src/main/java/com/cognifide/qa/bb/utils/YamlReader.java
+++ b/bb-core/src/main/java/com/cognifide/qa/bb/utils/YamlReader.java
@@ -22,11 +22,11 @@ package com.cognifide.qa.bb.utils;
 import java.io.IOException;
 import java.io.InputStream;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
@@ -75,6 +75,7 @@ public final class YamlReader {
   }
 
   private static InputStream readFile(String path) {
-    return YamlReader.class.getResourceAsStream(path + YAML);
+    String fullPath = StringUtils.endsWith(path, YAML) ? path : path + YAML;
+    return YamlReader.class.getResourceAsStream(fullPath);
   }
 }

--- a/bb-core/src/test/java/com/cognifide/qa/bb/config/YamlConfigTest.java
+++ b/bb-core/src/test/java/com/cognifide/qa/bb/config/YamlConfigTest.java
@@ -156,4 +156,29 @@ public class YamlConfigTest {
 
     assertThat(actual).containsOnly(context3Entires);
   }
+
+  @Test
+  public void loadConfig_shouldLoadAdditionalContexts_whenTheyAreAvailableInSeparateFilesAndActivated() {
+    Config userYaml = new Config();
+    DefaultConfig defConfig = new DefaultConfig();
+    defConfig.setContexts(Arrays.asList("additional-context1", "additional-context2"));
+    userYaml.setDefaultConfig(defConfig);
+    Map<String, Map<String, String>> contexts = new HashMap<>();
+    Map.Entry[] context1Entries = {entry("property1", "value1"), entry("property2", "value2")};
+    Map.Entry[] context2Entries = {entry("property3", "value3"), entry("property4", "value4")};
+    Map.Entry[] context3Entires = {entry("property5", "value5"), entry("property6", "value6")};
+    contexts.put("context1", mapOf(context1Entries));
+    contexts.put("context2", mapOf(context2Entries));
+    contexts.put("context3", mapOf(context3Entires));
+    userYaml.setContexts(contexts);
+
+    YamlConfig tested = mock(YamlConfig.class);
+    when(tested.readUserYaml()).thenReturn(userYaml);
+    doCallRealMethod().when(tested).loadConfig();
+
+    System.setProperty(YamlConfig.SYS_PROP_CONFIG_CONTEXTS, "context3");
+    Properties actual = tested.loadConfig();
+
+    assertThat(actual).containsOnly(context3Entires);
+  }
 }


### PR DESCRIPTION
## Description
After @Shaihuludus suggestions, additional contexts can now be loaded from separate files.

## Motivation and Context
This change might be helpful for people that keep lengthy properties files, like a list of page URLs.
This extends the changes introduced in #227 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code styleguide](https://github.com/Cognifide/bobcat/blob/master/CONTRIBUTING.md#styleguide) of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
