### PR TITLE
#274 upgrade of cucumber version to 3.0.2

### DIFF
--- a/bb-aem-touch-ui/pom.xml
+++ b/bb-aem-touch-ui/pom.xml
@@ -57,7 +57,7 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
         <dependency>
-            <groupId>info.cukes</groupId>
+            <groupId>io.cucumber</groupId>
             <artifactId>cucumber-guice</artifactId>
         </dependency>
         <dependency>

--- a/bb-aem-touch-ui/pom.xml
+++ b/bb-aem-touch-ui/pom.xml
@@ -57,10 +57,6 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.cucumber</groupId>
-            <artifactId>cucumber-guice</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>

--- a/bb-core/pom.xml
+++ b/bb-core/pom.xml
@@ -45,7 +45,7 @@ limitations under the License.
             <artifactId>selenium-htmlunit-driver</artifactId>
         </dependency>
         <dependency>
-            <groupId>info.cukes</groupId>
+            <groupId>io.cucumber</groupId>
             <artifactId>cucumber-guice</artifactId>
         </dependency>
         <dependency>

--- a/bb-cumber/pom.xml
+++ b/bb-cumber/pom.xml
@@ -42,11 +42,11 @@
             <artifactId>hamcrest-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>info.cukes</groupId>
+            <groupId>io.cucumber</groupId>
             <artifactId>cucumber-guice</artifactId>
         </dependency>
         <dependency>
-            <groupId>info.cukes</groupId>
+            <groupId>io.cucumber</groupId>
             <artifactId>cucumber-junit</artifactId>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@ limitations under the License.
         <jacoco.version>0.7.7.201606060606</jacoco.version>
         <selenium.version>3.11.0</selenium.version>
         <guice.version>3.0</guice.version>
-        <cucumber.version>1.2.3</cucumber.version>
+        <cucumber.version>3.0.2</cucumber.version>
         <version.logback>1.1.7</version.logback>
     </properties>
 
@@ -208,12 +208,12 @@ limitations under the License.
                 <version>3.2.3</version>
             </dependency>
             <dependency>
-                <groupId>info.cukes</groupId>
+                <groupId>io.cucumber</groupId>
                 <artifactId>cucumber-guice</artifactId>
                 <version>${cucumber.version}</version>
             </dependency>
             <dependency>
-                <groupId>info.cukes</groupId>
+                <groupId>io.cucumber</groupId>
                 <artifactId>cucumber-junit</artifactId>
                 <version>${cucumber.version}</version>
             </dependency>


### PR DESCRIPTION
Following changes are required in old tests:
In @CucumberOptions make sure that format is replaced with plugin
cucumber-guice.properties should be renamed to cucumber.properties