### PR TITLE
Fix the Default Checkbox element locator

### DIFF
--- a/bb-aem-65/src/main/java/com/cognifide/qa/bb/aem/core/component/dialog/dialogfields/DefaultCheckbox.java
+++ b/bb-aem-65/src/main/java/com/cognifide/qa/bb/aem/core/component/dialog/dialogfields/DefaultCheckbox.java
@@ -29,7 +29,7 @@ import com.cognifide.qa.bb.qualifier.PageObject;
 /**
  * Default implementation of {@link Checkbox}
  */
-@PageObject(xpath = "//*[contains(@class,'coral3-Checkbox')]/..")
+@PageObject(css = "coral-checkbox")
 public class DefaultCheckbox implements Checkbox {
 
   @FindBy(css = ".coral3-Checkbox-input")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The previous element locator proved to be wrong when handling multifield items
Required for https://github.com/Cognifide/bobcat-aem-tests/pull/20 and therefore for https://github.com/Cognifide/bobcat/issues/373

## Motivation and Context
<!--- Why is this change needed in the framework? -->
<!--- Provide links to any existing issues. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the [code styleguide](https://github.com/Cognifide/bobcat/blob/master/CONTRIBUTING.md#styleguide) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
